### PR TITLE
Update cli install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First of all, [download](https://golang.org/dl/) and install **Go**. Version `1.
 Installation is done by using the [`go install`](https://golang.org/cmd/go/#hdr-Compile_and_install_packages_and_dependencies) command and rename installed binary in `$GOPATH/bin`:
 
 ```bash
-go install github.com/create-go-app/cli/v3/cmd/cgapp
+go install github.com/create-go-app/cli/v3/cmd/cgapp@latest
 ```
 
 Also, macOS and GNU/Linux users available way to install via [Homebrew](https://brew.sh/):


### PR DESCRIPTION
After go 1.16, you need to specify the version in `go install`.