### PR TITLE
Implement getAbsoluteUrl function to abort the difference  in incoming url when use -t option

### DIFF
--- a/pkg/cgapp/git.go
+++ b/pkg/cgapp/git.go
@@ -6,8 +6,10 @@ package cgapp
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 )
@@ -30,7 +32,7 @@ func GitClone(templateType, templateURL string) error {
 		folder,
 		false,
 		&git.CloneOptions{
-			URL: fmt.Sprintf("https://%s", templateURL),
+			URL: getAbsoluteURL(templateURL),
 		},
 	)
 	if errPlainClone != nil {
@@ -43,4 +45,15 @@ func GitClone(templateType, templateURL string) error {
 	RemoveFolders(folder, []string{".git", ".github"})
 
 	return nil
+}
+
+func getAbsoluteURL(templateURL string) string {
+	templateURL = strings.TrimSpace(templateURL)
+	u, _ := url.Parse(templateURL)
+
+	if len(u.Scheme) == 0 {
+		u.Scheme = "https"
+	}
+
+	return u.String()
 }

--- a/pkg/cgapp/git_test.go
+++ b/pkg/cgapp/git_test.go
@@ -59,3 +59,44 @@ func TestGitClone(t *testing.T) {
 		}
 	}
 }
+
+func Test_getAbsoluteURL(t *testing.T) {
+	type args struct {
+		templateURL   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want string
+	}{
+		{
+			"successfully get absolute url from url with scheme",
+			args{
+				templateURL: "https://github.com/create-go-app/net_http-go-template",
+			},
+			"https://github.com/create-go-app/net_http-go-template",
+		},
+		{
+			"successfully get absolute url from url without scheme",
+			args{
+				templateURL: "github.com/create-go-app/net_http-go-template",
+			},
+			"https://github.com/create-go-app/net_http-go-template",
+		},
+		{
+			"successfully get absolute url from url starting space",
+			args{
+				templateURL: " github.com/create-go-app/net_http-go-template",
+			},
+			"https://github.com/create-go-app/net_http-go-template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAbsoluteURL(tt.args.templateURL); got != tt.want {
+				t.Errorf("getAbsoluteURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -111,7 +111,6 @@ var (
 			Name: "backend",
 			Prompt: &survey.Input{
 				Message: "Enter URL to the custom backend repository:",
-				Help:    "No need to specify `http://` or `https://` protocol.",
 			},
 			Validate: survey.Required,
 		},
@@ -119,7 +118,6 @@ var (
 			Name: "frontend",
 			Prompt: &survey.Input{
 				Message: "Enter URL to the custom frontend repository:",
-				Help:    "No need to specify `http://` or `https://` protocol.",
 				Default: "none",
 			},
 		},


### PR DESCRIPTION
**What this PR is changing or adding?**

Implement `getAbsoluteUrl` function in the `GitClone` function and  remove help message for `create -t` option because I think it is no longer needed.

**Before/after or any other screenshots**

![スクリーンショット 2022-02-14 11 26 09](https://user-images.githubusercontent.com/37904275/153792599-b1bd6322-c9ca-43e3-b526-8b445daec033.png)


**Which issues are fixed by this PR?**

1. When developers use the `create -t` option,  they can input the url without being aware of the schema.

Or I would like to add some kind of error message when a url with a scheme is entered. 

 Please consider this proposal, let me know your comments. Thanks.

## Pre-launch Checklist

- [x] I have read and fully accepted project's [code of conduct](https://github.com/create-go-app/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation and/or comments to the code.
- [x] All existing and new tests are passing successfully.
