### PR TITLE
fix(readme): remove broken Recordit.co link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ cgapp create [OPTION]
 
 ![cgapp_create][cgapp_create_gif]
 
-- 📺 Full demo video: https://recordit.co/OQAwkZBrjN
 - 📖 Docs: https://github.com/create-go-app/cli/wiki/Command-create
 
 ### `deploy`
@@ -119,7 +118,6 @@ cgapp deploy [OPTION]
 
 ![cgapp_deploy][cgapp_deploy_gif]
 
-- 📺 Full demo video: https://recordit.co/ishTf0Au1x
 - 📖 Docs: https://github.com/create-go-app/cli/wiki/Command-deploy
 
 ## 📝 Production-ready project templates


### PR DESCRIPTION
**What this PR is changing or adding?**

This fork fixes the broken screen recording link from recordit.co, which no longer hosts the original video. The domain has changed or the original content is no longer available.

Note: If you have the full video or a new screen recording, please update the README with a working link (e.g., upload to a reliable video hosting platform like Loom, Vimeo, or YouTube).

# Before
![image](https://github.com/user-attachments/assets/9a4a43bb-2d61-43bd-8c45-b83ba9016863)
# After:
![image](https://github.com/user-attachments/assets/da0f8bcc-d0ed-4fd1-8f8d-a96e9aeb596c)

**Which issues are fixed by this PR?**
#179  

- [x] I have read and fully accepted project's [code of conduct](https://github.com/create-go-app/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation and/or comments to the code.
- [x] All existing and new tests are passing successfully.
